### PR TITLE
PHP基礎課題5 スレッド一覧で投稿者IDではなく、スレッドIDが表示される様に修正

### DIFF
--- a/thread.html.php
+++ b/thread.html.php
@@ -59,7 +59,7 @@
                         </a>
                     </div>
                     <div class="thread-meta">
-                        投稿者ID: <?= htmlspecialchars($thread['member_id']) ?> | 登録日時: <?= htmlspecialchars($thread['created_at']) ?>
+                        スレッドID: <?= htmlspecialchars($thread['id']) ?> | 登録日時: <?= htmlspecialchars($thread['created_at']) ?>
                     </div>
                 </div>
             <?php endforeach; ?>


### PR DESCRIPTION
PHP基礎課題5
スレッド一覧で投稿者IDではなく、スレッドIDが表示される様に修正